### PR TITLE
fixed menubar invisibleness

### DIFF
--- a/trunk/main.py
+++ b/trunk/main.py
@@ -109,6 +109,12 @@ class Ui_Selekti(QtGui.QMainWindow):
 
         self.show()
 
+    def set_styles(self):
+        self.mainMenu.setPalette(QPalette(Qt.white))
+        self.current_directory_label.setStyleSheet("QLabel { color: white; }")
+        self.sub_directories_label.setStyleSheet("QLabel { color: white; }")
+        self.setStyleSheet("QMainWindow { background-color: rgb(53, 53, 53); }")      
+
     def warnings_Button_clicked(self, qmodelindex):
         
         if not self.unimportedFiles:
@@ -443,26 +449,9 @@ class ImageData:
 
 if __name__ == "__main__":
     app = QtGui.QApplication(sys.argv)
-    # Force the style to be the same on all OSs: https://stackoverflow.com/questions/48256772/dark-theme-for-in-qt-widgets
-    # app.setStyle("Fusion")
-
-    # Now use a palette to switch to dark colors:
-    palette = QPalette()
-    palette.setColor(QPalette.Window, QColor(53, 53, 53))
-    palette.setColor(QPalette.WindowText, Qt.white)
-    palette.setColor(QPalette.Base, QColor(25, 25, 25))
-    palette.setColor(QPalette.AlternateBase, QColor(53, 53, 53))
-    palette.setColor(QPalette.ToolTipBase, Qt.white)
-    palette.setColor(QPalette.ToolTipText, Qt.white)
-    # palette.setColor(QPalette.Text, Qt.white)
-    palette.setColor(QPalette.Button, QColor(53, 53, 53))
-    palette.setColor(QPalette.ButtonText, Qt.white)
-    palette.setColor(QPalette.BrightText, Qt.red)
-    palette.setColor(QPalette.Link, QColor(42, 130, 218))
-    palette.setColor(QPalette.Highlight, QColor(42, 130, 218))
-    palette.setColor(QPalette.HighlightedText, Qt.black)
-    app.setPalette(palette)
 
     ui = Ui_Selekti()
+    ui.set_styles()
+
     sys.exit(app.exec_())
 


### PR DESCRIPTION
at least on Windows, the items in the menubar (File, Warnings, Help) weren't visible until the mouse hovered over them and even then you could barely make out what they said. I'm not sure how changing the QPalette of the menubar to white made it work but i'm not complaining.
I also fixed the hard-to-read black font color on the current and subdir import notices
(i fixed these things a while ago but never published the branch)